### PR TITLE
bt: host: Link with the ELMFAT library

### DIFF
--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -1,10 +1,14 @@
 zephyr_library()
 zephyr_library_link_libraries(subsys__bluetooth)
 
+if(CONFIG_BT_INTERNAL_STORAGE)
+  zephyr_library_sources(storage.c)
+  zephyr_library_link_libraries_ifdef(CONFIG_FAT_FILESYSTEM_ELM ELMFAT)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_BT_HCI_RAW          hci_raw.c)
 zephyr_library_sources_ifdef(CONFIG_BT_DEBUG_MONITOR    monitor.c)
 zephyr_library_sources_ifdef(CONFIG_BT_TINYCRYPT_ECC    hci_ecc.c)
-zephyr_library_sources_ifdef(CONFIG_BT_INTERNAL_STORAGE storage.c)
 zephyr_library_sources_ifdef(CONFIG_BT_A2DP             a2dp.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AVDTP            avdtp.c)
 zephyr_library_sources_ifdef(CONFIG_BT_RFCOMM           rfcomm.c)


### PR DESCRIPTION
The ELMFAT library is organized as a Zephyr library with a public
interface. When BT/host/storage.c uses elmfat it needs acccess to the
public interface of ELMFAT.

Signed-off-by: Sebastian Boe <sebastian.boe@nordicsemi.no>